### PR TITLE
Add payment method modal

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -234,6 +234,156 @@
             <p id="total"></p>
           </li>
         </ul>
+        <hr class="mt-5" />
+      </div>
+      <div class="container">
+        <h4 class="mt-4 mb-3">Formas de pago</h4>
+        <p>
+          <span id="payment-method"> No ha seleccionado </span>
+          <span>
+            <!-- Button trigger modal -->
+            <button
+              type="button"
+              class="btn btn-link"
+              data-bs-toggle="modal"
+              data-bs-target="#exampleModal"
+            >
+              Seleccionar
+            </button>
+          </span>
+        </p>
+
+        <!-- Modal -->
+        <div
+          class="modal fade"
+          id="exampleModal"
+          tabindex="-1"
+          aria-labelledby="exampleModalLabel"
+          aria-hidden="true"
+        >
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h1 class="modal-title fs-5" id="exampleModalLabel">
+                  Formas de pago
+                </h1>
+                <hr />
+              </div>
+              <div class="modal-body">
+                <div class="col form-check p-0">
+                  <div class="container ps-4">
+                    <input
+                      class="form-check-input"
+                      type="radio"
+                      name="exampleRadios"
+                      id="credit-card-btn"
+                      value="option1"
+                    />
+                    <label class="form-check-label" for="exampleRadios1">
+                      Tarjeta de crédito
+                    </label>
+                  </div>
+                  <hr class="mt-4 mb-4" />
+                  <div class="row">
+                    <div class="row mb-3 gap-1">
+                      <div class="col-7">
+                        <label for="credit-card-number" class="form-label">
+                          Número de tarjeta
+                        </label>
+                        <input
+                          type="text"
+                          maxlength="16"
+                          class="form-control credit-card-input"
+                          id="credit-card-number"
+                          required
+                          oninput="this.value = this.value.replace(/[^0-9]/g, '')"
+                        />
+                      </div>
+                      <div class="col-4">
+                        <label for="ccv-number" class="form-label">
+                          Código de seg.
+                        </label>
+                        <input
+                          type="tel"
+                          maxlength="3"
+                          class="form-control credit-card-input"
+                          id="ccv-number"
+                          pattern="[0-9]*"
+                          required
+                          oninput="this.value = this.value.replace(/[^0-9]/g, '')"
+                        />
+                      </div>
+                    </div>
+                    <label for="expiration-date" class="form-label">
+                      Vencimiento (MM/AA)
+                    </label>
+                    <span
+                      class="col-4 d-flex flex-row align-items-center gap-2 mb-3"
+                    >
+                      <input
+                        type="tel"
+                        class="form-control credit-card-input"
+                        name="month"
+                        placeholder="MM"
+                        maxlength="2"
+                        size="2"
+                        required
+                        oninput="this.value = this.value.replace(/[^0-9]/g, '')"
+                      />
+                      <span>/</span>
+                      <input
+                        type="tel"
+                        class="form-control credit-card-input"
+                        name="year"
+                        placeholder="YY"
+                        maxlength="2"
+                        size="2"
+                        oninput="this.value = this.value.replace(/[^0-9]/g, '')"
+                      />
+                    </span>
+                  </div>
+                  <div class="containter ps-4 mb-3">
+                    <div class="form-check p-0">
+                      <input
+                        class="form-check-input"
+                        type="radio"
+                        name="exampleRadios"
+                        id="bank-transfer-btn"
+                        value="option2"
+                      />
+                      <label class="form-check-label" for="exampleRadios2">
+                        Transferencia bancaria
+                      </label>
+                    </div>
+                  </div>
+                  <hr class="mt-4 mb-4" />
+                  <div class="mb-3">
+                    <label for="account-number" class="form-label">
+                      Número de transferencia
+                    </label>
+                    <input
+                      type="tel"
+                      class="form-control bank-transfer-input"
+                      id="account-number"
+                      required
+                      oninput="this.value = this.value.replace(/[^0-9]/g, '')"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div class="modal-footer">
+                <button
+                  type="button"
+                  class="btn btn-primary m-0"
+                  data-bs-dismiss="modal"
+                  id="close-btn"
+                >
+                  Cerrar
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </main>
     <footer class="text-muted">

--- a/js/cart.js
+++ b/js/cart.js
@@ -2,8 +2,13 @@ import getJSONData from './utils/getJSONData.js';
 import { CART_INFO_URL } from './constants/API.js';
 
 const radioButtons = document.querySelectorAll('input[type = "radio"]');
+const creditCardBtn = document.getElementById('credit-card-btn');
+const creditCardInputs = document.querySelectorAll('.credit-card-input');
+const bankTransferBtn = document.getElementById('bank-transfer-btn');
+const bankTransferInput = document.querySelector('.bank-transfer-input');
+const typeOfPayment = document.getElementById('payment-method');
 
-let cart = new Array();
+let cart = Array();
 
 function isProductInCart(cartProducts, productID) {
   if (cartProducts.length === 0) true;
@@ -61,6 +66,26 @@ function updateItemQuantity(DOMItem, newQuantity) {
   localStorage.setItem('cart', JSON.stringify(cart));
 }
 
+creditCardBtn.addEventListener('click', function () {
+  if (creditCardBtn.checked) {
+    bankTransferInput.setAttribute('disabled', '');
+  }
+  creditCardInputs.forEach((input) => {
+    input.removeAttribute('disabled', '');
+  });
+  typeOfPayment.innerHTML = 'Tarjeta de crédito';
+});
+
+bankTransferBtn.addEventListener('click', function () {
+  if (bankTransferBtn.checked) {
+    creditCardInputs.forEach((input) => {
+      input.setAttribute('disabled', '');
+    });
+  }
+  bankTransferInput.removeAttribute('disabled', '');
+  typeOfPayment.innerHTML = 'Transferencia bancaria';
+});
+
 document.addEventListener('DOMContentLoaded', async () => {
   cart = await getCartProducts().then((data) => data);
   const tbody = document.querySelector('tbody');
@@ -86,7 +111,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     tbody.appendChild(row);
   });
 
-  // Phone devices
+  // Mobile devices
   cart.forEach((product) => {
     const { id, name, unitCost, count, currency, image } = product;
     const listGroup = document.querySelector('#list-group');
@@ -152,6 +177,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
   });
 });
+
 function getBuyResume() {
   const DOMsubtotal = document.querySelector('#subtotal');
   const DOMshippingCost = document.querySelector('#costo-envio');


### PR DESCRIPTION
- Add credit card and bank transfer as payment methods (with their own required information)
- Implement inputs disable/enable functionality when one of the two payment options is selected
- Restrict inputs entries to numbers only and to the required length